### PR TITLE
Update Negroni import path

### DIFF
--- a/gzip/gzip.go
+++ b/gzip/gzip.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/codegangsta/negroni"
+	"github.com/urfave/negroni"
 )
 
 // These compression constants are copied from the compress/gzip package.


### PR DESCRIPTION
The URL `github.com/codegangsta/negroni` now redirects to `github.com/urfave/negroni` on the web, please consider this PR to update the reference so negroni-gzip will build.