### PR TITLE
[Fix] Double encoding of responses with preset "Content-Encoding"

### DIFF
--- a/gzip/gzip_test.go
+++ b/gzip/gzip_test.go
@@ -77,6 +77,27 @@ func Test_ServeHTTP_CompressionWithNoGzipHeader(t *testing.T) {
 	}
 }
 
+func Test_ServeHTTP_CompressionWithPrecompressedResponse(t *testing.T) {
+	gzipHandler := Gzip(DefaultCompression)
+	w := httptest.NewRecorder()
+
+	req, err := http.NewRequest("GET", "http://localhost/foobar", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header.Set(headerAcceptEncoding, encodingGzip)
+
+	gzipHandler.ServeHTTP(w, req, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(headerContentEncoding, "deflate")
+		testHTTPContent(w, r)
+	})
+
+	if w.Body.String() != gzipTestString {
+		t.Fail()
+	}
+}
+
 func Test_ServeHTTP_InvalidCompressionLevel(t *testing.T) {
 	gzipHandler := Gzip(gzipInvalidCompressionLevel)
 	w := httptest.NewRecorder()


### PR DESCRIPTION
Looks like there are two issues with the current implementation as far as pre-encoded responses:

1. The "Content-Encoding" check compares the value to "gzip", which means that if a response is encoded with "deflate", this implementation will gzip the deflated response and replace the header with "gzip" confusing the client.
2. The implementation checks response's "Content-Encoding" header before it calls `next(w,r)` to process the request through the middleware/handler chain.  This header will always be empty because the Handler has not had a chance to populate the headers and body.

To fix these, this patch will do the following:

1. Bypass compression for responses with any defined "Content-Encoding" header.
2. The "Content-Encoding" check is moved to ResponseWriter's `WriteHeader` method to make sure that it happens after the middleware/handler chain, but before the headers are sent to the client.

Notes:
To disable compression in `WriteHeader`, I'm modifying the gzipResponseWriter object, so now it has to be passed by reference (not value) so that the changes stick.



