### PR TITLE
Fix invalid Content-Length if set in handler

### DIFF
--- a/gzip/gzip.go
+++ b/gzip/gzip.go
@@ -47,6 +47,12 @@ func (grw *gzipResponseWriter) WriteHeader(code int) {
 		grw.w.Reset(ioutil.Discard)
 		grw.w = nil
 	}
+
+	// Avoid sending Content-Length header before compression. The length would
+	// be invalid, and some browsers like Safari will report
+	// "The network connection was lost." errors
+	grw.Header().Del(headerContentLength)
+
 	grw.ResponseWriter.WriteHeader(code)
 	grw.wroteHeader = true
 }
@@ -118,9 +124,6 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.Ha
 	// Call the next handler supplying the gzipResponseWriter instead of
 	// the original.
 	next(&grw, r)
-
-	// Delete the content length after we know we have been written to.
-	grw.Header().Del(headerContentLength)
 
 	gz.Close()
 }


### PR DESCRIPTION
If a handler later in the chain sets the Content-Length header, removing
it afterwards is already too late. The header was already sent the
client.
This change will prevent to write the header in all next handlers, so
that the compressed body doesn't have a different size than
Content-Length.
Browsers like Safari (but also Firefox and Chrome for mobile) will
report connection errors instead of displaying the content of the page.

closes #14