### PR TITLE
chore(mod): make middleware compatible with go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/phyber/negroni-gzip
+
+go 1.15
+
+require (
+	github.com/urfave/negroni v1.0.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/urfave/negroni v1.0.0 h1:kIimOitoypq34K7TG7DUaJ9kq/N4Ofuwi1sjz0KipXc=
+github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=


### PR DESCRIPTION
You juste need to tag your release to v1.0.0 then.
Closes #16 